### PR TITLE
Extension Diagnosesicherheit: Use type coding instead of type code

### DIFF
--- a/src/main/groovy/projects/mii/modul/diagnose/condition.groovy
+++ b/src/main/groovy/projects/mii/modul/diagnose/condition.groovy
@@ -4,6 +4,8 @@ import static de.kairos.fhir.centraxx.metamodel.RootEntities.diagnosis
 
 /**
  * represented by CXX DIAGNOSIS
+ * Specified by (stable release) https://www.medizininformatik-initiative.de/Kerndatensatz/Modul_Diagnose/Condition.html v.1.0.4
+ * Working draft (future release) https://simplifier.net/guide/MedizininformatikInitiative-ModulDiagnosen-ImplementationGuide/Condition
  * @author Jonas Küttner
  * @since v.1.8.0, CXX.v.3.18.1
  * hints:
@@ -61,8 +63,10 @@ condition {
       if (context.source[diagnosis().diagnosisCertainty()]) {
         extension {
           url = "http://fhir.de/StructureDefinition/icd-10-gm-diagnosesicherheit"
-          system = "https://fhir.kbv.de/CodeSystem/KBV_CS_SFHIR_ICD_DIAGNOSESICHERHEIT"
-          valueCode = context.source[diagnosis().diagnosisCertainty()] as String
+          valueCoding {
+            system = "https://fhir.kbv.de/CodeSystem/KBV_CS_SFHIR_ICD_DIAGNOSESICHERHEIT"
+            code = context.source[diagnosis().diagnosisCertainty()] as String
+          }
         }
       }
       extension {


### PR DESCRIPTION
The Extension 'http://fhir.de/StructureDefinition/icd-10-gm-diagnosesicherheit' definition allows for the types [Coding] but found type code.

Example JSON:

https://www.medizininformatik-initiative.de/Kerndatensatz/Modul_Diagnose/Condition.html >
"Beispiele" > "Beispiel (ICD-10-GM Diagnose mit Kreuz-Stern-System und Zusatzkennzeichen)"

or

https://simplifier.net/MedizininformatikInitiative-ModulDiagnosen/ExampleConditionMehrfachkodierungPrimaercode/~json