### PR TITLE
Fix ecrf code of gender field

### DIFF
--- a/src/main/groovy/projects/gecco/crf/patientFromCRF.groovy
+++ b/src/main/groovy/projects/gecco/crf/patientFromCRF.groovy
@@ -80,7 +80,7 @@ patient {
   active = context.source[studyVisitItem().studyMember().patientContainer().patientStatus()]
 
   final def crfItemGender = context.source[studyVisitItem().crf().items()].find {
-    "COV_GECCO_GESCHLECHT_GEBURT" == it[CrfItem.TEMPLATE]?.getAt(CrfTemplateField.LABOR_VALUE)?.getAt(LaborValue.CODE)
+    "COV_GECCO_Geschlecht_GEBURT" == it[CrfItem.TEMPLATE]?.getAt(CrfTemplateField.LABOR_VALUE)?.getAt(LaborValue.CODE)
   }
   if (crfItemGender) {
     crfItemGender[CrfItem.CATALOG_ENTRY_VALUE][CatalogEntry.CODE]?.each { final gen ->


### PR DESCRIPTION
FHIR Element Patient.gender wurde nicht ausgeleitet, weil Code im Transformationsscript "COV_GECCO_GESCHLECHT_GEBURT" aber im ERCF "COV_GECCO_Geschlecht_GEBURT".

Bitte um Ablehnung des PR/entsprechende Info, falls dies kein Problem des Skriptes, sondern u.U. z.B. mit veralteter Version des ECRF zusammenhängen sollte.