### PR TITLE
Datentyp des Parameters für Aufruf von mapEthnicityCode()

### DIFF
--- a/src/main/groovy/projects/gecco/crf/patientFromCRF.groovy
+++ b/src/main/groovy/projects/gecco/crf/patientFromCRF.groovy
@@ -38,12 +38,14 @@ patient {
   final def crfItemEthn = context.source[studyVisitItem().crf().items()].find {
     "COV_GECCO_ETHNISCHE_ZUGEHOERIGKEIT" == it[CrfItem.TEMPLATE]?.getAt(CrfTemplateField.LABOR_VALUE)?.getAt(LaborValue.CODE)
   }
-  if (crfItemEthn[CrfItem.CATALOG_ENTRY_VALUE] != [] && crfItemEthn) {
-    extension {
-      url = "https://www.netzwerk-universitaetsmedizin.de/fhir/StructureDefinition/ethnic-group"
-      valueCoding {
-        system = "http://snomed.info/sct"
-        code = mapEthnicityCode(crfItemEthn[CrfItem.CATALOG_ENTRY_VALUE][CatalogEntry.CODE] as String)
+  if (crfItemEthn) {
+    crfItemEthn[CrfItem.CATALOG_ENTRY_VALUE][CatalogEntry.CODE]?.each { final ethn ->
+      extension {
+        url = "https://www.netzwerk-universitaetsmedizin.de/fhir/StructureDefinition/ethnic-group"
+        valueCoding {
+          system = "http://snomed.info/sct"
+          code = mapEthnicityCode(ethn as String)
+        }
       }
     }
   }


### PR DESCRIPTION
Das Mapping in mapEthnicityCode() greift nicht (bzw. liefert immer den default), weil diese Funktion mit einem multi valued Datentyp aufgerufen wird (wohl weil catalogEntryValue vom Datentyp her multi valued) und das Konvertieren dieser Variable nach String z.B. für den Fall des Codes "COV_KAUKASIER" nicht das für Mapping nötigen String "COV_KAUKASIER" sondern den auch den Datentyp mit abbildenden String "[COV_KAUKASIER]" erzeugt.

Durch Code dieses PR liefe es auf die selbe Art und Weise wie bei crfItemGender. (Ob in diesem Fall angebracht, kann ich noch nicht beurteilen, jedenfalls zumindest als Markierung der entsprechenden Codestellen/Problembereiche für dieses Issue brauchbar).