### PR TITLE
Docs: Fix mermaid parse error in graph

### DIFF
--- a/docs/FHIR-Custom-Export-HDRP-Setup.md
+++ b/docs/FHIR-Custom-Export-HDRP-Setup.md
@@ -79,8 +79,8 @@ graph LR
     classDef transformation fill: #bfb, stroke: #333, stroke-width: 1px;
     classDef export fill: #fbb, stroke: #333, stroke-width: 1px;
     class DB database;
-class EntityLoader, Entities, ConvertToMaps, EntityMaps entity;
-class GroovyEngine,GroovyScripts, FHIRResources transformation;
+class EntityLoader,Entities,ConvertToMaps,EntityMaps entity;
+class GroovyEngine,GroovyScripts,FHIRResources transformation;
 class RESTEndpoint,ExportedBundles export;
 ```
 


### PR DESCRIPTION
Parse error on line 42:
...ityLoader, Entities, ConvertToMaps, Enti
-----------------------^
Expecting 'SEMI', 'NEWLINE', 'EOF', 'AMP', 'COLON', 'DOWN', 'DEFAULT', 'NUM', 'COMMA', 'NODE_STRING', 'BRKT', 'MINUS', 'MULT', 'UNICODE_TEXT', got 'SPACE'